### PR TITLE
Make launch tasks more descriptive

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 				},
 				"initialConfigurations": [
 					{
-						"name": "HashLink",
+						"name": "HashLink (launch)",
 						"request": "launch",
 						"type": "hl",
 						"hxml": "build.hxml",
@@ -131,7 +131,7 @@
 						"preLaunchTask": "Build"
 					},
 					{
-						"name": "HashLink",
+						"name": "HashLink (attach)",
 						"request": "attach",
 						"port" : 6112,
 						"type": "hl",


### PR DESCRIPTION
Currently when it generates tasks, both have same name "HashLink", yet they behave differently, creating confusion in the debug dropdown list. Adding parenthesis description for each should fix it.