### PR TITLE
Changed `null` value in stack frame to `undefined`

### DIFF
--- a/src/HLAdapter.hx
+++ b/src/HLAdapter.hx
@@ -486,7 +486,7 @@ class HLAdapter extends adapter.DebugSession {
 					name : stackStr(f),
 					source : {
 						name : f.file.split("/").pop(),
-						path : file == null ? undefined : (isWindow ? file.split("/").join("\\") : file),
+						path : file == null ? js.Lib.undefined : (isWindow ? file.split("/").join("\\") : file),
 						sourceReference : file == null ? allocValue(VUnkownFile(f.file)) : 0,
 					},
 					line : f.line,

--- a/src/HLAdapter.hx
+++ b/src/HLAdapter.hx
@@ -486,7 +486,7 @@ class HLAdapter extends adapter.DebugSession {
 					name : stackStr(f),
 					source : {
 						name : f.file.split("/").pop(),
-						path : file == null ? null : (isWindow ? file.split("/").join("\\") : file),
+						path : file == null ? undefined : (isWindow ? file.split("/").join("\\") : file),
 						sourceReference : file == null ? allocValue(VUnkownFile(f.file)) : 0,
 					},
 					line : f.line,


### PR DESCRIPTION
The VS Code debugging API requires the `path` property in a stack frame source object to be either a string or `undefined`. The current value `null` isn't supported and can cause (as it did for me) issues where no debug information is displayed at all.

See documentation [here](https://github.com/Microsoft/vscode-debugadapter-node/blob/64665fe18a0316b2a871df4b36cff214c28d2598/protocol/src/debugProtocol.ts#L1308-L1311) and [here](https://github.com/Microsoft/vscode-debugadapter-node/blob/64665fe18a0316b2a871df4b36cff214c28d2598/protocol/src/debugProtocol.ts#L468-L469).

This PR changes the `null` value to `undefined` to fix this error.