### PR TITLE
Electron FFI fix + Haxe 4.2.1 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # requires compiling native extensions with electron support
 NPARAMS=--runtime=electron --target=12.0.4 --disturl=https://atom.io/download/electron
 LINUX_VM=ncannasse@virtbuntu
-PREBUILT_OSX_BINDINGS=https://gist.github.com/rcstuber/9f60840ccc371c8d53b18c6331b2bf7f/raw/4b5772d40fdae3c9c0f776ea53a43a71810db8b8/ffi_bindings_osx.tar.gz
+PREBUILT_OSX_BINDINGS=https://gist.github.com/rcstuber/3e9a46fa0aae9f729648445a0a9717d7/raw/221e37bcbf22c2cae216aa664ee960e8413899f5/ffi_bindings_osx.tar.gz
 
 all:
 
@@ -19,8 +19,6 @@ cleanup:
 # git pull && sudo rm -rf node_modules && sudo make deps on LINUX_VM before running this
 import_linux_bindings:
 	cp bindings.js node_modules/bindings/	
-	make LIB=ffi-napi NAME=ffi_bindings _import_linux_bindings
-	make LIB=ref-napi NAME=binding _import_linux_bindings
 	make LIB=deasync NAME=deasync _import_linux_bindings
 
 _import_linux_bindings:
@@ -31,9 +29,7 @@ _import_linux_bindings:
 
 bundle_mac_bindings:
 	TMP=$$(mktemp -d); \
-	cp 	node_modules/ffi-napi/build/Release/ffi_bindings.node \
-		node_modules/ref-napi/build/Release/binding.node \
-		node_modules/deasync/build/Release/deasync.node \
+	cp 	node_modules/deasync/build/Release/deasync.node \
 		$$TMP; \
 	tar -cvzf ffi_bindings_osx.tar.gz -C $$TMP .; \
 	rm -rf $$TMP;
@@ -44,8 +40,6 @@ import_mac_bindings:
 	wget --no-check-certificate --content-disposition $(PREBUILT_OSX_BINDINGS)
 	TMP=.tmp; mkdir -p $$TMP; \
 	tar -C $$TMP -xf ffi_bindings_osx.tar.gz; \
-	make SRC=$$TMP LIB=ffi-napi NAME=ffi_bindings _import_mac_bindings; \
-	make SRC=$$TMP LIB=ref-napi NAME=binding _import_mac_bindings; \
 	make SRC=$$TMP LIB=deasync NAME=deasync _import_mac_bindings; \
 	rm -rf $$TMP; \
 	rm ffi_bindings_osx.tar.gz;

--- a/src/Extension.hx
+++ b/src/Extension.hx
@@ -16,8 +16,8 @@ class Extension {
 
 			var hlVersion:String = js.node.ChildProcess.execSync('$hl --version');
 			if(hlVersion <= "1.11.0") {
-				final visitButton = "Get from GitHub";
-				Vscode.window.showErrorMessage('Your version of Hashlink (${hlVersion}) does not support debugging on Mac. Install a newer version from here:', visitButton).then(function(choice) {
+				final visitButton:String = "Get from GitHub";
+				Vscode.window.showErrorMessage('Your version of Hashlink (${hlVersion}) does not support debugging on Mac. Install a newer version from here:', null, visitButton).then(function(choice) {
 					if (choice == visitButton) {
 						Vscode.env.openExternal(Uri.parse("https://github.com/HaxeFoundation/hashlink"));
 					}

--- a/src/Extension.hx
+++ b/src/Extension.hx
@@ -16,7 +16,7 @@ class Extension {
 
 			var hlVersion:String = js.node.ChildProcess.execSync('$hl --version');
 			if(hlVersion <= "1.11.0") {
-				final visitButton:String = "Get from GitHub";
+				final visitButton = "Get from GitHub";
 				Vscode.window.showErrorMessage('Your version of Hashlink (${hlVersion}) does not support debugging on Mac. Install a newer version from here:', null, visitButton).then(function(choice) {
 					if (choice == visitButton) {
 						Vscode.env.openExternal(Uri.parse("https://github.com/HaxeFoundation/hashlink"));

--- a/src/HLAdapter.hx
+++ b/src/HLAdapter.hx
@@ -266,7 +266,7 @@ class HLAdapter extends DebugSession {
 			if( err.message == "spawn hl ENOENT" )
 				error(cast response, "Could not start 'hl' process, executable was not found in PATH.\nRestart VSCode or computer.");
 			else
-				error(cast response, 'Failed to start hl process ($err)');
+				error(cast response, 'Failed to start hl process (${err.message})');
 		});
 	}
 


### PR DESCRIPTION
This PR includes new prebuilds for MacOS fixing issue https://github.com/vshaxe/hashlink-debugger/issues/97 and fixes two compile errors produced under Haxe 4.2.1. 