### PR TITLE
Restore socket creation for hl debugger

### DIFF
--- a/hld/Debugger.hx
+++ b/hld/Debugger.hx
@@ -154,6 +154,7 @@ class Debugger {
 			});
 		});
 		#else
+		sock = new sys.net.Socket();
 		try {
 			sock.connect(new sys.net.Host(host), port);
 		} catch( e : Dynamic ) {


### PR DESCRIPTION
Socket creation was moved in https://github.com/vshaxe/hashlink-debugger/commit/2af48a4a818d7ceda6f8487241a20963157adef5#diff-4ca30b29a1d30867977108f076745caaf39dd5c2340771a60d82beca03492a12L118 but only recreated in the `#if hxnodejs` branch