### PR TITLE
Make backtrace show previous line if triggered by watch

### DIFF
--- a/hld/Debugger.hx
+++ b/hld/Debugger.hx
@@ -606,9 +606,9 @@ class Debugger {
 
 		var eip = getReg(tid, Eip);
 		var asmPos = eip.sub(jit.codeStart);
+		if( isWatchbreak )
+			asmPos -= 1;
 		var e = jit.resolveAsmPos(asmPos);
-		if( isWatchbreak && e != null )
-			e.fpos -= 1;
 		var inProlog = false;
 
 		//trace(eip,"0x"+api.readByte(eip, 0), e);

--- a/hld/Debugger.hx
+++ b/hld/Debugger.hx
@@ -378,7 +378,7 @@ class Debugger {
 			mainThread = stoppedThread;
 
 		readThreads();
-		prepareStack();
+		prepareStack(cmd.r == Watchbreak);
 		return cmd.r;
 	}
 
@@ -426,9 +426,9 @@ class Debugger {
 			threads.set(currentThread,{ id : currentThread, stackTop: null, exception: null, name : null });
 	}
 
-	function prepareStack() {
+	function prepareStack( isWatchbreak=false ) {
 		currentStackFrame = 0;
-		currentStack = makeStack(currentThread);
+		currentStack = makeStack(currentThread, isWatchbreak);
 	}
 
 	function skipFunction( fidx : Int ) {
@@ -567,7 +567,7 @@ class Debugger {
 				var r = wait(true);
 				if( r != SingleStep || currentThread != tid )
 					break;
-				var st = makeStack(tid,1)[0];
+				var st = makeStack(tid,false,1)[0];
 				if( isRet ) {
 					if( op == 0xC3 ) {
 						if( st == null ) {
@@ -594,7 +594,7 @@ class Debugger {
 		return Breakpoint;
 	}
 
-	function makeStack(tid,max = 0) {
+	function makeStack( tid, isWatchbreak : Bool, max = 0 ) {
 		var stack = [];
 		var tinf = threads.get(tid);
 		if( tinf == null || tinf.stackTop == null )
@@ -607,6 +607,8 @@ class Debugger {
 		var eip = getReg(tid, Eip);
 		var asmPos = eip.sub(jit.codeStart);
 		var e = jit.resolveAsmPos(asmPos);
+		if( isWatchbreak && e != null )
+			e.fpos -= 1;
 		var inProlog = false;
 
 		//trace(eip,"0x"+api.readByte(eip, 0), e);


### PR DESCRIPTION
When setting a data watch point for `y` in the following code, the debugger will first "stop" at line 5 instead of line 4, which is a little bit confusing as it is the line 4 which modified `y`.

```haxe
static var y = 0;
static function main() {
	trace(y); // <- watch y here and continue
	y = 15 * 15;
	trace(y); // <- break has a backtrace point at this line instead of previous line
}
```

This PR make backtrace return line 4 instead of line 5 in case of watch.