### PR TITLE
Add debug var context menu view as hex/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ cleanup:
 	/bin/find . -name *.map | xargs rm -rf 
 package: cleanup
 	#npm install vsce -g
-	haxe -cp src -lib vscode -lib vshaxe -D js-es=6 -js extension.js Extension
+	haxe -cp src -lib vscode -lib vshaxe -lib vscode-debugadapter -D js-es=6 -js extension.js Extension
 	vsce package
 	
 # to get token : 

--- a/package.json
+++ b/package.json
@@ -158,6 +158,20 @@
 					}
 				]
 			}
+		],
+		"menus": {
+			"debug/variables/context": [
+				{
+					"command": "hldebug.var.formatInt",
+					"when": "debugType == 'hl'"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "hldebug.var.formatInt",
+				"title": "View as Hex & Bin"
+			}
 		]
 	},
 	"__metadata": {

--- a/src/Extension.hx
+++ b/src/Extension.hx
@@ -5,6 +5,7 @@ class Extension {
 	@:expose("activate")
 	static function main(context:ExtensionContext) {
 		Vscode.debug.registerDebugConfigurationProvider("hl", {resolveDebugConfiguration: resolveDebugConfiguration});
+		context.subscriptions.push(Vscode.commands.registerCommand("hldebug.var.formatInt", formatInt));
 	}
 
 	static function resolveDebugConfiguration(folder:Null<WorkspaceFolder>, config:DebugConfiguration,
@@ -57,4 +58,32 @@ class Extension {
 			});
 		});
 	}
+
+	inline static function toString(value:Int, base:Int):String {
+		#if js
+		return untyped value.toString(base);
+		#else
+		throw "Not implemented";
+		#end
+	}
+
+	static function formatInt(args:VariableContextCommandArg) {
+		var i = Std.parseInt(args.variable.value);
+		if (i == null)
+			return;
+		Vscode.window.showInformationMessage(args.variable.name + "(" + i + ") = 0x" + toString(i,16) + " = 0b" + toString(i,2));
+	}
+}
+
+typedef Container = {
+	var name : String;
+	var variablesReference : Int;
+	var ?expensive : Bool;
+	var ?value : String;
+}
+
+typedef VariableContextCommandArg = {
+	var sessionId : String;
+	var container : Container;
+	var variable : vscode.debugProtocol.DebugProtocol.Variable;
 }


### PR DESCRIPTION
The original idea is to display `haxe.EnumFlags<>` as Hex & Binary format in the debugger, but as it's an abstract of `Int` and difficult to know the original type at runtime.
The second thought is to display the `Int` value as Hex & Binary format when required, which is support by `"debug/variables/context"` context menu contribution in VSCode (Ref https://github.com/microsoft/vscode/issues/28025).

So I just made a small Int to Hex & Bin converter in Extension (* which do not require communication between extension.js and adapter.js). Usage:
![image](https://github.com/vshaxe/hashlink-debugger/assets/22941109/d5fbee89-5a4a-4004-b5f5-a8f2fbd1bcde)
![image](https://github.com/vshaxe/hashlink-debugger/assets/22941109/e59de75a-236c-4749-9663-a91970a9fd71)

