### PR TITLE
[CI] add tests for assigns sort

### DIFF
--- a/tests/unit/TestNoOptimizeCapture/Test.hx
+++ b/tests/unit/TestNoOptimizeCapture/Test.hx
@@ -1,0 +1,18 @@
+class Test {
+	var classvar = 10;
+
+	public function new() {
+		var functionvar = 15;
+		function bar(x) {
+			classvar = functionvar + x;
+			functionvar = x + 1;
+		}
+		bar(7);
+		trace(functionvar);
+		trace(classvar);
+	}
+
+	static function main() {
+		new Test();
+	}
+}

--- a/tests/unit/TestNoOptimizeCapture/compile.txt
+++ b/tests/unit/TestNoOptimizeCapture/compile.txt
@@ -1,0 +1,1 @@
+-D hl_no_opt

--- a/tests/unit/TestNoOptimizeCapture/input.txt
+++ b/tests/unit/TestNoOptimizeCapture/input.txt
@@ -1,0 +1,11 @@
+--ci
+test.hl
+"b Test.hx:7"
+"b Test.hx:11"
+r
+"p this"
+"p functionvar"
+r
+"p this"
+"p functionvar"
+q

--- a/tests/unit/TestNoOptimizeCapture/output.txt
+++ b/tests/unit/TestNoOptimizeCapture/output.txt
@@ -1,0 +1,19 @@
+> b Test.hx:7
+Breakpoint set line 7
+> b Test.hx:11
+Breakpoint set line 11
+> r
+Thread paused Test.hx:7
+> p this
+Test : Test
+  classvar = 10 : Int
+> p functionvar
+[15] : Array<Int>
+> r
+Thread paused Test.hx:11 ($Test::__constructor__)
+> p this
+Test : Test
+  classvar = 22 : Int
+> p functionvar
+[8] : Array<Int>
+> q


### PR DESCRIPTION
Caused by `fun.assigns` not sorted as expected. Fix in haxe

Failed example:

```
> p this
([15], Test) : $Closure:0
  $0 = [15] : Array<Int>
  $1 = Test : Test
> p functionvar
Error Unknown identifier functionvar
Called from hld.Eval.evalExpr (hld/Eval.hx line 220)
Called from hld.Eval.eval (hld/Eval.hx line 101)
Called from hld.Debugger.getValue (hld/Debugger.hx line 832)
Called from hld.Main.command (hld/Main.hx line 281)
Called from hld.Main.command (hld/Main.hx line 281)
```