### PR TITLE
Hot-Reload prepare: use Pointer as asmPos

### DIFF
--- a/hld/Debugger.hx
+++ b/hld/Debugger.hx
@@ -6,9 +6,14 @@ enum StepMode {
 	Into;
 }
 
-typedef Address = { ptr : Pointer, t : format.hl.Data.HLType };
+@:publicFields @:structInit
+class Address {
+	var ptr : Pointer;
+	var t : format.hl.Data.HLType;
+}
 
-typedef WatchPoint = {
+@:publicFields @:structInit
+class WatchPoint {
 	var addr : Address;
 	var regs : Array<{ offset : Int, bits : Int, r : Api.Register }>;
 	var forReadWrite : Bool;
@@ -19,10 +24,16 @@ class StackRawInfo {
 	var fidx : Int;
 	var fpos : Int;
 	var codePos : Pointer;
-	var ebp : hld.Pointer;
+	var ebp : Null<hld.Pointer>;
 }
 
-typedef StackInfo = { file : String, line : Int, ebp : Pointer, ?context : { obj : format.hl.Data.ObjPrototype, field : String } };
+@:publicFields @:structInit
+class StackInfo {
+	var file : String;
+	var line : Int;
+	var ebp : Pointer;
+	var context : Null<{ obj : format.hl.Data.ObjPrototype, field : String }>;
+}
 
 class Debugger {
 
@@ -806,7 +817,7 @@ class Debugger {
 		if( frame == null ) frame = currentStackFrame;
 		var f = currentStack[frame];
 		if( f == null )
-			return {file:"???", line:0, ebp:Pointer.make(0, 0)};
+			return { file : "???", line : 0, ebp : Pointer.make(0, 0), context : null };
 		return stackInfo(f);
 	}
 
@@ -821,7 +832,7 @@ class Debugger {
 		return out;
 	}
 
-	function stackInfo( f ) {
+	function stackInfo( f ) : StackInfo {
 		var s = module.resolveSymbol(f.fidx, f.fpos);
 		return { file : s.file, line : s.line, ebp : f.ebp, context : module.getMethodContext(f.fidx) };
 	}

--- a/hld/Debugger.hx
+++ b/hld/Debugger.hx
@@ -14,7 +14,13 @@ typedef WatchPoint = {
 	var forReadWrite : Bool;
 }
 
-typedef StackRawInfo = { fidx : Int, fpos : Int, codePos : Int, ebp : hld.Pointer };
+@:publicFields @:structInit
+class StackRawInfo {
+	var fidx : Int;
+	var fpos : Int;
+	var codePos : Pointer;
+	var ebp : hld.Pointer;
+}
 
 typedef StackInfo = { file : String, line : Int, ebp : Pointer, ?context : { obj : format.hl.Data.ObjPrototype, field : String } };
 

--- a/hld/Eval.hx
+++ b/hld/Eval.hx
@@ -1670,16 +1670,3 @@ class Eval {
 	}
 
 }
-
-// Map<Int64, V> does not work on JS, see https://github.com/HaxeFoundation/haxe/issues/9872
-class Int64Map<T> extends haxe.ds.BalancedTree<haxe.Int64, T> {
-	override function compare(k1:haxe.Int64, k2:haxe.Int64):Int {
-		return if( k1 == k2 ) {
-			0;
-		} else if( k1 > k2 ) {
-			1;
-		} else {
-			-1;
-		}
-	}
-}

--- a/hld/Int64Map.hx
+++ b/hld/Int64Map.hx
@@ -1,0 +1,14 @@
+package hld;
+
+// Map<Int64, V> does not work on JS, see https://github.com/HaxeFoundation/haxe/issues/9872
+class Int64Map<T> extends haxe.ds.BalancedTree<haxe.Int64, T> {
+	override function compare(k1:haxe.Int64, k2:haxe.Int64):Int {
+		return if( k1 == k2 ) {
+			0;
+		} else if( k1 > k2 ) {
+			1;
+		} else {
+			-1;
+		}
+	}
+}

--- a/hld/JitInfo.hx
+++ b/hld/JitInfo.hx
@@ -116,7 +116,8 @@ class JitInfo {
 		return dbg.start + (dbg.large ? dbg.offsets.getInt32(pos << 2) : dbg.offsets.getUInt16(pos << 1));
 	}
 
-	public function resolveAsmPos( asmPos : Int ) {
+	public function resolveAsmPos( codePtr : Pointer ) {
+		var asmPos = codePtr.sub(codeStart);
 		if( asmPos < 0 || asmPos > codeSize )
 			return null;
 		var min = 0;

--- a/hld/JitInfo.hx
+++ b/hld/JitInfo.hx
@@ -116,10 +116,16 @@ class JitInfo {
 		return dbg.start.offset(dbg.large ? dbg.offsets.getInt32(pos << 2) : dbg.offsets.getUInt16(pos << 1));
 	}
 
-	public inline function isCodePtr( codePtr : Pointer ) {
+	public function isCodePtr( codePtr : Pointer ) : Bool {
 		if( codePtr < codeStart || codePtr > codeEnd )
 			return false;
 		return true;
+	}
+
+	public function codePtrToString( codePtr : Pointer ) : String {
+		if( codePtr < codeStart || codePtr > codeEnd )
+			return '$codePtr';
+		return '$codePtr(${codePtr.sub(codeStart)})';
 	}
 
 	public function resolveAsmPos( codePtr : Pointer ) : Null<Debugger.StackRawInfo> {

--- a/hld/JitInfo.hx
+++ b/hld/JitInfo.hx
@@ -39,7 +39,7 @@ class JitInfo {
 		return oldThreadInfos != null || flags.has(Threads);
 	}
 
-	function readPointer() : Pointer {
+	private function readPointer() : Pointer {
 		if( is64 )
 			return Pointer.make(input.readInt32(), input.readInt32());
 		return Pointer.make(input.readInt32(),0);

--- a/hld/JitInfo.hx
+++ b/hld/JitInfo.hx
@@ -97,7 +97,7 @@ class JitInfo {
 			var start = codeStart.offset(input.readInt32());
 			var large = input.readByte() != 0;
 			var offsets = input.read((nops + 1) * (large ? 4 : 2));
-			functionByCodePos.set(start, i);
+			functionByCodePos.set(start.i64, i);
 			functions.push({
 				start : start,
 				large : large,
@@ -161,7 +161,7 @@ class JitInfo {
 	}
 
 	public function functionFromAddr( p : Pointer ) {
-		return functionByCodePos.get(p);
+		return functionByCodePos.get(p.i64);
 	}
 
 }

--- a/hld/Pointer.hx
+++ b/hld/Pointer.hx
@@ -37,6 +37,9 @@ abstract Pointer(hl.Bytes) to hl.Bytes {
 	@:op(a < b) static function opLt( a : Pointer, b : Pointer ) : Bool {
 		return a.addr() < b.addr();
 	}
+	@:op(a == b) static function opEq( a : Pointer, b : Pointer ) : Bool {
+		return a.addr() == b.addr();
+	}
 
 	public function toString() {
 		var i = this.address();
@@ -89,6 +92,9 @@ abstract Pointer(haxe.Int64) to haxe.Int64 {
 	}
 	@:op(a < b) static function opLt( a : Pointer, b : Pointer ) : Bool {
 		return a.i64 < b.i64;
+	}
+	@:op(a == b) static function opEq( a : Pointer, b : Pointer ) : Bool {
+		return a.i64 == b.i64;
 	}
 
 	public function toString() {

--- a/hld/Pointer.hx
+++ b/hld/Pointer.hx
@@ -13,7 +13,7 @@ abstract Pointer(hl.Bytes) to hl.Bytes {
 		return new Pointer(this.offset(pos));
 	}
 
-	public inline function sub( p : Pointer ) {
+	public inline function sub( p : Pointer ) : Int {
 		return this.subtract(p);
 	}
 
@@ -45,6 +45,9 @@ abstract Pointer(hl.Bytes) to hl.Bytes {
 	}
 	@:op(a == b) static function opEq( a : Pointer, b : Pointer ) : Bool {
 		return a.addr() == b.addr();
+	}
+	@:op(a != b) static function opNeq( a : Pointer, b : Pointer ) : Bool {
+		return a.addr() != b.addr();
 	}
 
 	public function toString() {
@@ -107,6 +110,9 @@ abstract Pointer(haxe.Int64) to haxe.Int64 {
 	}
 	@:op(a == b) static function opEq( a : Pointer, b : Pointer ) : Bool {
 		return a.i64 == b.i64;
+	}
+	@:op(a != b) static function opNeq( a : Pointer, b : Pointer ) : Bool {
+		return a.i64 != b.i64;
 	}
 
 	public function toString() {

--- a/hld/Pointer.hx
+++ b/hld/Pointer.hx
@@ -34,8 +34,14 @@ abstract Pointer(hl.Bytes) to hl.Bytes {
 	@:op(a > b) static function opGt( a : Pointer, b : Pointer ) : Bool {
 		return a.addr() > b.addr();
 	}
+	@:op(a >= b) static function opGte( a : Pointer, b : Pointer ) : Bool {
+		return a.addr() >= b.addr();
+	}
 	@:op(a < b) static function opLt( a : Pointer, b : Pointer ) : Bool {
 		return a.addr() < b.addr();
+	}
+	@:op(a <= b) static function opLte( a : Pointer, b : Pointer ) : Bool {
+		return a.addr() <= b.addr();
 	}
 	@:op(a == b) static function opEq( a : Pointer, b : Pointer ) : Bool {
 		return a.addr() == b.addr();
@@ -90,8 +96,14 @@ abstract Pointer(haxe.Int64) to haxe.Int64 {
 	@:op(a > b) static function opGt( a : Pointer, b : Pointer ) : Bool {
 		return a.i64 > b.i64;
 	}
+	@:op(a >= b) static function opGte( a : Pointer, b : Pointer ) : Bool {
+		return a.i64 >= b.i64;
+	}
 	@:op(a < b) static function opLt( a : Pointer, b : Pointer ) : Bool {
 		return a.i64 < b.i64;
+	}
+	@:op(a <= b) static function opLte( a : Pointer, b : Pointer ) : Bool {
+		return a.i64 <= b.i64;
 	}
 	@:op(a == b) static function opEq( a : Pointer, b : Pointer ) : Bool {
 		return a.i64 == b.i64;


### PR DESCRIPTION
I don't know if we'll support hot-reload one day, but this changes is only a refacto that uses `Pointer` for asmPos, instead of an `Int` offset from `codeStart`.