### PR TITLE
Fix for stacktrace request to make adapter usable with non-VSCode DAP server

### DIFF
--- a/src/HLAdapter.hx
+++ b/src/HLAdapter.hx
@@ -391,6 +391,7 @@ class HLAdapter extends DebugSession {
 				run();
 			}
 		};
+		sendResponse(response);
 	}
 
 	function stopDebug() {
@@ -650,8 +651,9 @@ class HLAdapter extends DebugSession {
 		//debug("Stacktrace request");
 		setThread(args.threadId);
 		var bt = dbg.getBackTrace();
-		var start = args.startFrame;
-		var count = args.levels == null || args.levels + start > bt.length ? bt.length - start : args.levels;
+		var start = args.startFrame == null ? 0 : args.startFrame;
+		var levels = args.levels == null ? bt.length : args.levels;
+		var count = levels + start > bt.length ? bt.length - start : levels;
 		response.body = {
 			stackFrames : [for( i in 0...count ) {
 				var f = bt[start + i];


### PR DESCRIPTION
This minor fix allows the debugger adapter to be used with other DAP-enabled editors.
Some clients do not pass **startFrame** and/or **levels** parameters, which is why frame selection is not performed and the response contains an empty body